### PR TITLE
Add Substack formatter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # psychedelic3d
+
+This repository includes a simple Python script that fetches article content from the web and outputs Substack-ready Markdown.
+
+## Substack formatter
+
+The `substack_formatter.py` script downloads a web page, extracts the title and main paragraphs, and writes a Markdown file you can paste into Substack.
+
+### Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the formatter:
+   ```bash
+   python substack_formatter.py <url> output.md
+   ```
+
+The generated `output.md` contains a Markdown-formatted version of the article.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests>=2.31
+beautifulsoup4>=4.12

--- a/substack_formatter.py
+++ b/substack_formatter.py
@@ -1,0 +1,45 @@
+import sys
+from typing import List, Tuple
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_article(url: str) -> Tuple[str, List[str]]:
+    """Download a URL and return its title and paragraph texts."""
+    # Disable proxy use by default to avoid corporate proxy issues in some environments
+    response = requests.get(url, timeout=10, proxies={"http": None, "https": None})
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    title_tag = soup.find("title")
+    title = title_tag.get_text(strip=True) if title_tag else url
+
+    article = soup.find("article")
+    if article:
+        paragraphs = [p.get_text(strip=True) for p in article.find_all("p")]
+    else:
+        paragraphs = [p.get_text(strip=True) for p in soup.find_all("p")]
+    paragraphs = [p for p in paragraphs if p]
+    return title, paragraphs
+
+
+def format_markdown(title: str, paragraphs: List[str]) -> str:
+    body = "\n\n".join(paragraphs)
+    return f"# {title}\n\n{body}\n"
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: python substack_formatter.py <url> <output_file>")
+        return 1
+    url, output_path = sys.argv[1], sys.argv[2]
+    title, paragraphs = fetch_article(url)
+    markdown = format_markdown(title, paragraphs)
+    with open(output_path, "w", encoding="utf-8") as fh:
+        fh.write(markdown)
+    print(f"Wrote Substack-ready Markdown to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Python script `substack_formatter.py` to fetch web pages and output Substack-ready Markdown
- document usage and dependencies in README
- include `requirements.txt` for needed packages

## Testing
- `python -m pip install -r requirements.txt`
- `python substack_formatter.py https://www.example.com/ sample.md` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d7d28928083288d1dc25ee3e48538